### PR TITLE
Add Ballerina implementation report

### DIFF
--- a/implementation-reports/HUB-Ballerina.md
+++ b/implementation-reports/HUB-Ballerina.md
@@ -1,0 +1,42 @@
+# Ballerina
+
+Implementation Home Page URL: [ballerina/websub](https://ballerina.io/learn/api-docs/ballerina/websub.html) 
+
+Source code repo URL(s) (optional): https://github.com/ballerina-lang/ballerina
+* [x] 100% open source implementation
+
+Programming Language(s): Ballerina 
+
+Developer(s): [Ballerina](https://ballerina.io/)
+
+Answers are:
+* [x] Confirmed via websub.rocks (for applicable results)
+* [ ] All results are self-reported
+
+## Subscription
+
+* [x] 100: Supports subscriptions with `hub.mode`, `hub.topic` and `hub.callback`  
+* [x] 101: Supports subscriptions with `hub.mode`, `hub.topic`, `hub.callback` and `hub.secret`
+  * Self-reported with JSON content  
+* [x] 102: Ignores unrecognized parameters in the subscription request
+* [x] 103: Allows subscribers to re-request active subscriptions before they expire
+* [x] 104: Supports unsubscription requests
+* [x] 1xx: Sends a properly formatted verification request for subscribing and unsubscribing
+* [x] Allows subscribers to request a specific lease duration
+  * If not, then describe the default lease duration issued, or other specifics here
+
+(1xx denotes that you can can use any of the 100-104 tests to confirm this feature)
+
+## Distribution
+
+* [x] 100: Sends a notification with a matching content-type of the topic URL
+  * publisher defines content to deliver  
+* [x] 100: Sends a notification with the full contents of the topic
+* [x] 101: Sends a notification with a valid signature
+  * Please select the signature method(s) that the hub uses to sign requests
+  * [x] sha1
+  * [x] sha256
+  * [ ] sha384
+  * [ ] sha512
+* [ ] Sends only a diff of the topic URL for Atom or RSS feeds
+

--- a/implementation-reports/PUBLISHER-Ballerina.md
+++ b/implementation-reports/PUBLISHER-Ballerina.md
@@ -1,0 +1,40 @@
+# Ballerina
+
+Implementation Home Page URL: [ballerina/websub](https://ballerina.io/learn/api-docs/ballerina/websub.html)
+
+Source code repo URL(s) (optional): https://github.com/ballerina-lang/ballerina
+* [x] 100% open source implementation
+
+Programming Language(s): Ballerina
+
+Developer(s): [Ballerina](https://ballerina.io/)
+
+Answers are:
+* [x] Confirmed via websub.rocks (for applicable results)
+* [ ] All results are self-reported
+
+## Discovery
+
+* The publisher produces URLs with the following content types:
+  * [ ] HTML
+  * [ ] Atom
+  * [ ] RSS
+  * [ ] JSON
+  * Other - The developer/user specifies the URLs. Util functions are available to add link headers.
+* [x] The publisher advertises the hub and self URLs in HTTP headers
+* The publisher advertises the hub and self URLs in the body of the document for the following content types:
+  * [ ] HTML in <link> tags in the HTML <head>
+  * [ ] HTML in <link> tags in the body (currently not allowed, but the restriction of placing the <link> tags in the <head> is *at risk* so if an implementation requires advertising the URLs in the body this limitation may be dropped)
+  * [ ] Atom in <link> elements
+  * [ ] RSS in <atom:link> elements
+* [ ] The publisher advertises the hub URL using the `.host-meta` well-known URI (currently *at risk*)
+
+## Distribution
+
+* [x] The publisher notifies the hub when a topic has been updated. (This is required, although the implementation details are not specified, in order to allow flexibility in how hubs are implemented. e.g. a hub integrated with the publishing software does not need a standardized notification mechanism.)
+
+If your publisher uses an external hub, please describe how the publisher notifies the hub of new content:
+
+* [x] The publisher sends a POST request to the hub with `hub.mode=publish&hub.topic=_______`
+* [x] Other: Also allows sending a POST request, with the new content, to the hub with `hub
+.mode=publish&hub.topic=_______` 

--- a/implementation-reports/SUBSCRIBER-Ballerina.md
+++ b/implementation-reports/SUBSCRIBER-Ballerina.md
@@ -1,0 +1,53 @@
+# Ballerina
+
+Implementation Home Page URL: [ballerina/websub](https://ballerina.io/learn/api-docs/ballerina/websub.html)
+
+Source code repo URL(s) (optional): https://github.com/ballerina-lang/ballerina
+* [x] 100% open source implementation
+
+Programming Language(s): Ballerina
+
+Developer(s): [Ballerina](https://ballerina.io/)
+
+Answers are:
+* [x] Confirmed via websub.rocks (for applicable results)
+* [ ] All results are self-reported
+
+## Discovery
+
+* [x] 100: HTTP header discovery - discovers the hub and self URLs from HTTP headers
+* [ ] 101: HTML tag discovery - discovers the hub and self URLs from the HTML `<link>` tags
+* [ ] 102: Atom feed discovery - discovers the hub and self URLs from the XML `<link>` tags
+* [ ] 103: RSS feed discovery - discovers the hub and self URLs from the XML `<atom:link>` tags
+* [x] 104: Discovery priority - prioritizes the hub and self in HTTP headers over the links in the body
+
+## Subscription
+
+* [x] 1xx: Successfully creates a subscription
+* [x] 200: Subscribing to a URL that reports a different rel=self
+* [x] 201: Subscribing to a topic URL that sends an HTTP 302 temporary redirect
+* [x] 202: Subscribing to a topic URL that sends an HTTP 301 permanent redirect
+* [x] 203: Subscribing to a hub that sends a 302 temporary redirect
+* [x] 204: Subscribing to a hub that sends a 301 permanent redirect
+* [x] 205: Rejects a verification request with an invalid topic URL 
+* [x] 1xx: Requests a subscription using a secret (optional)
+  * Please select the signature method(s) that the subscriber recognizes. All methods listed below are currently acceptable for the hub to choose:
+  * [x] sha1
+  * [x] sha256
+  * [ ] sha384
+  * [ ] sha512
+* [x] 1xx: Requests a subscription with a specific `lease_seconds` (optional, hub may ignore)
+* [x] Callback URL is unique per subscription (should)
+  * Developer specifies the URL  
+* [x] Callback URL is an unguessable URL (should)
+  * Developer specifies the URL 
+* [x] 1xx: Sends an unsubscription request
+
+## Distribution
+
+* [x] 300: Returns HTTP 2xx when the notification payload is delivered
+* [x] 1xx: Verifies a valid signature for authenticated distribution
+* [x] 301: Rejects a distribution request with an invalid signature
+* [x] 302: Rejects a distribution request with no signature when the subscription was made with a secret
+
+(1xx denotes that you can can use any of the 100-104 tests to confirm this feature)


### PR DESCRIPTION
This PR adds the WebSub implementation report for Ballerina.

- Implementation Home Page URL: [ballerina/websub](https://ballerina.io/learn/api-docs/ballerina/websub.html)
- Example URL: [WebSub Service Integration Sample](https://ballerina.io/learn/by-example/websub-service-integration-sample.html)