### PR TITLE
Fix Content-type in content negotiation example 4

### DIFF
--- a/source.html
+++ b/source.html
@@ -352,7 +352,7 @@ Host: example.com
 Accept-Language: de-DE
 
 HTTP/1.1 200 Ok
-Content-type: text/html
+Content-type: application/json
 
 Link: &lt;/feed-de.json&gt;; rel="self"
 Link: &lt;https://hub.example.com/&gt;; rel="hub"


### PR DESCRIPTION
Hi,

I found this example setting a `text/html` content type but is responding in `json`, so this is just to set it to `application/json` as per previous examples.